### PR TITLE
拆分：独立 Steam 成就翻译库（扁平路径与投稿 workflow）

### DIFF
--- a/.github/ISSUE_TEMPLATE/translation_contribution_en.yml
+++ b/.github/ISSUE_TEMPLATE/translation_contribution_en.yml
@@ -1,0 +1,32 @@
+name: Submit Steam achievement translation (English helper)
+description: Auxiliary English form; Chinese form is preferred.
+title: "[Translation] <Game name> (<Steam app ID>)"
+labels: [translation-contribution]
+body:
+  - type: markdown
+    attributes:
+      value: Please use the Chinese template if possible. Upload `UserGameStatsSchema_<app_id>.zip` containing exactly one matching `.bin` file.
+  - type: input
+    id: game_name
+    attributes:
+      label: Game name
+    validations:
+      required: true
+  - type: input
+    id: app_id
+    attributes:
+      label: Steam app ID
+    validations:
+      required: true
+  - type: input
+    id: store_url
+    attributes:
+      label: Steam store URL
+    validations:
+      required: true
+  - type: textarea
+    id: schema_zip
+    attributes:
+      label: Achievement schema ZIP
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/translation_contribution_zh.yml
+++ b/.github/ISSUE_TEMPLATE/translation_contribution_zh.yml
@@ -1,0 +1,55 @@
+name: 提交 Steam 成就翻译（中文）
+description: 上传一个已翻译的 UserGameStatsSchema_<app_id>.zip
+title: "[翻译投稿] <游戏名> (<Steam app ID>)"
+labels: [translation-contribution]
+body:
+  - type: input
+    id: game_name
+    attributes:
+      label: 游戏名
+      placeholder: The Binding of Isaac: Rebirth 以撒的结合：重生
+    validations:
+      required: true
+  - type: input
+    id: app_id
+    attributes:
+      label: Steam app ID
+      placeholder: "250900"
+    validations:
+      required: true
+  - type: input
+    id: store_url
+    attributes:
+      label: Steam 商店地址
+      placeholder: https://store.steampowered.com/app/250900/
+    validations:
+      required: true
+  - type: checkboxes
+    id: languages
+    attributes:
+      label: 上传文件包含的语言
+      options:
+        - label: schinese
+        - label: tchinese
+        - label: english
+        - label: japanese
+        - label: koreana
+  - type: input
+    id: extra_languages
+    attributes:
+      label: 其他 Steam 语言代码
+      description: 如有多个，请用逗号分隔；没有则填写 none。
+      placeholder: none
+  - type: textarea
+    id: schema_zip
+    attributes:
+      label: 成就 schema ZIP
+      description: 上传 `UserGameStatsSchema_<app_id>.zip`，ZIP 内必须只包含一个同名 `.bin` 文件。
+      placeholder: 请把 ZIP 拖到这里。
+    validations:
+      required: true
+  - type: textarea
+    id: notes
+    attributes:
+      label: 备注
+      description: 可填写翻译来源、术语说明或需要维护者注意的内容。

--- a/.github/workflows/translation-contribution.yml
+++ b/.github/workflows/translation-contribution.yml
@@ -1,0 +1,39 @@
+name: Translation contribution
+
+on:
+  issues:
+    types: [opened, edited, labeled]
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  review:
+    if: contains(github.event.issue.labels.*.name, 'translation-contribution')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout translation library
+        uses: actions/checkout@v4
+
+      - name: Guard issue label
+        run: python workflow-scripts/github_issue_guard.py "$GITHUB_EVENT_PATH"
+
+      - name: Validate submission and update library files
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: python workflow-scripts/library_submission_bot.py --event "$GITHUB_EVENT_PATH"
+
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: translation-library/issue-${{ github.event.issue.number }}
+          title-path: pr_title.txt
+          body-path: pr_body.md
+          commit-message: 添加 Steam 成就翻译投稿 #${{ github.event.issue.number }}
+          labels: translation-contribution

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,33 @@
+# 贡献指南
+
+感谢你为 Steam 成就翻译库投稿。本仓库面向中文用户，中文说明和中文 issue 模板是默认入口；英文内容仅作为辅助。
+
+## 投稿前检查
+
+1. 在 `README.md` 和 `index.json` 中搜索 Steam app ID，确认没有重复投稿。
+2. 确认文件名为 `UserGameStatsSchema_<app_id>.bin`。
+3. 将该文件压缩为只包含一个文件的 `UserGameStatsSchema_<app_id>.zip`。
+4. 确认上传文件包含你在 issue 中勾选或填写的 Steam 语言字段，例如 `schinese`、`tchinese`、`english`。
+
+## 投稿流程
+
+1. 新建 issue，选择“提交 Steam 成就翻译（中文）”。
+2. 填写游戏名、Steam app ID、Steam 商店地址、语言代码，并上传 ZIP。
+3. GitHub Actions 会运行 `.github/workflows/translation-contribution.yml`。
+4. 初审通过后，机器人会在投稿分支中加入 `files/<app_id>/UserGameStatsSchema_<app_id>.bin`，并更新 `index.json`、`README.md`、`README_EN.md`。
+5. 维护者审核后合并 PR。
+
+## 路径约定
+
+独立仓库使用扁平化路径：
+
+- 成就文件：`files/<app_id>/UserGameStatsSchema_<app_id>.bin`
+- 机器索引：`index.json`
+- 中文索引：`README.md`
+- 英文辅助索引：`README_EN.md`
+
+请不要再使用原 skill 仓库中的 `achievement-library/` 前缀。
+
+## 不属于本仓库的内容
+
+不要向本仓库提交 `SKILL.md`、`VERSION`、`scripts/steam_bkv_tool.py`、Codex skill 安装说明、skill 打包脚本或 release workflow。这些内容应继续留在原 skill 仓库或由原项目引用本仓库数据。

--- a/CONTRIBUTING_EN.md
+++ b/CONTRIBUTING_EN.md
@@ -1,0 +1,13 @@
+# Contributing
+
+Thank you for contributing to the Steam Achievement Translation Library. Chinese documentation and Chinese issue templates are the default entry point; this English guide is auxiliary.
+
+## Submission flow
+
+1. Search `README.md` and `index.json` for the Steam app ID to avoid duplicates.
+2. Name the schema file `UserGameStatsSchema_<app_id>.bin`.
+3. Zip exactly one schema file as `UserGameStatsSchema_<app_id>.zip`.
+4. Open the Chinese translation contribution issue template and upload the ZIP.
+5. The automation writes accepted files to `files/<app_id>/`, updates `index.json`, `README.md`, and `README_EN.md`, then prepares a review PR.
+
+Do not submit Codex skill runtime files such as `SKILL.md`, `VERSION`, `scripts/steam_bkv_tool.py`, skill installer docs, packaging assets, or release workflows.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,45 @@
+# Steam 成就翻译库
+
+简体中文 | [English](README_EN.md)
+
+本仓库是从 `steam-achievement-localizer-skill` 拆分出来的独立 **Steam 成就翻译数据仓库**。这里不再维护 Codex skill 本体、安装包或运行时脚本，只维护社区投稿的 `UserGameStatsSchema_<app_id>.bin` 翻译文件、索引和投稿自动化。
+
+## 快速入口
+
+- 查找翻译：查看 [翻译库索引](#游戏列表)，可搜索 Steam app ID、游戏名、贡献者或语言代码。
+- 投稿翻译：使用中文 issue 模板“提交 Steam 成就翻译”，上传 `UserGameStatsSchema_<app_id>.zip`。
+- 贡献规范：优先阅读 [中文贡献指南](CONTRIBUTING.md)。英文版见 [CONTRIBUTING_EN.md](CONTRIBUTING_EN.md)。
+
+## 仓库结构
+
+```text
+.
+├── files/                         # 社区提交的成就 schema 文件
+├── index.json                     # 机器可读索引
+├── README.md                      # 中文默认索引与项目说明
+├── README_EN.md                   # 英文辅助说明
+├── CONTRIBUTING.md                # 中文贡献指南
+├── CONTRIBUTING_EN.md             # 英文辅助贡献指南
+├── workflow-scripts/              # GitHub Actions 投稿维护脚本
+└── .github/
+    ├── ISSUE_TEMPLATE/            # 投稿 issue 模板（中文优先）
+    └── workflows/                 # 翻译投稿自动化 workflow
+```
+
+> 路径已从原仓库的 `achievement-library/files/`、`achievement-library/index.json` 调整为独立仓库根目录下的 `files/`、`index.json`，避免出现 `achievement-library/achievement-library` 嵌套。
+
+## 使用说明
+
+下载所需游戏的 `UserGameStatsSchema_<app_id>.bin` 后，请使用你信任的本地工具应用到 Steam 本地成就 schema。替换本地 Steam 文件前请自行备份。
+
+## 游戏列表
+
+暂无已收录游戏。迁移时保留了独立仓库结构和索引格式；后续合并投稿后，自动化脚本会更新本节和 `index.json`。
+
+## 迁移说明
+
+本仓库只接收翻译库相关内容：索引、社区投稿数据目录、投稿模板、贡献指南以及 GitHub Actions 维护脚本。未迁移 `SKILL.md`、`VERSION`、`scripts/steam_bkv_tool.py`、skill 安装/打包说明和相关 workflow。
+
+## 许可证
+
+MIT。原始游戏内容、成就文本、Steam schema 内容及相关文件版权归对应游戏开发商、发行商及其他权利方所有；投稿翻译文本版权归对应贡献者所有，投稿即表示允许本仓库展示、索引并分发其提交的成就文件用于社区本地化。

--- a/README_EN.md
+++ b/README_EN.md
@@ -1,0 +1,19 @@
+# Steam Achievement Translation Library
+
+[简体中文](README.md) | English
+
+This repository is the standalone Steam achievement translation data library split from `steam-achievement-localizer-skill`. It no longer hosts the Codex skill runtime, installer, packaging workflow, or usage docs. The default entry point is the Chinese README; this file is an auxiliary English summary.
+
+## Layout
+
+- `files/`: community-submitted `UserGameStatsSchema_<app_id>.bin` files.
+- `index.json`: machine-readable index.
+- `README.md`: primary Chinese index and project documentation.
+- `CONTRIBUTING.md`: primary Chinese contribution guide.
+- `workflow-scripts/`: GitHub Actions helpers for submission review and index maintenance.
+
+Paths were flattened from the original `achievement-library/` subtree: `achievement-library/files/` became `files/`, and `achievement-library/index.json` became `index.json`.
+
+## What was not migrated
+
+Codex skill files such as `SKILL.md`, `VERSION`, `scripts/steam_bkv_tool.py`, skill installation docs, packaging assets, and skill release workflows are intentionally not part of this repository.

--- a/index.json
+++ b/index.json
@@ -1,0 +1,5 @@
+{
+  "version": 1,
+  "description": "Community-submitted Steam achievement schema translations.",
+  "entries": []
+}

--- a/workflow-scripts/github_issue_guard.py
+++ b/workflow-scripts/github_issue_guard.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+"""Small guard used by GitHub Actions to ensure translation issues use the correct labels."""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+
+def main() -> None:
+    event = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8")) if len(sys.argv) > 1 else {}
+    labels = {label.get("name") for label in (event.get("issue") or {}).get("labels", []) if isinstance(label, dict)}
+    if "translation-contribution" not in labels:
+        raise SystemExit("This workflow only handles issues labeled translation-contribution.")
+
+
+if __name__ == "__main__":
+    main()

--- a/workflow-scripts/library_submission_bot.py
+++ b/workflow-scripts/library_submission_bot.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shutil
+import sys
+import tempfile
+import urllib.parse
+import urllib.request
+import zipfile
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+INDEX_PATH = REPO_ROOT / "index.json"
+HUMAN_INDEX_PATH = REPO_ROOT / "README.md"
+HUMAN_INDEX_EN_PATH = REPO_ROOT / "README_EN.md"
+FILES_ROOT = REPO_ROOT / "files"
+LANGUAGE_RE = re.compile(r"^[a-z][a-z0-9_]{1,31}$")
+SCHEMA_NAME_RE = re.compile(r"^UserGameStatsSchema_(\d+)\.bin$", re.I)
+ZIP_NAME_RE = re.compile(r"^UserGameStatsSchema_(\d+)\.zip$", re.I)
+ATTACHMENT_RE = re.compile(r"\[([^\]]+)\]\((https://github\.com/user-attachments/[^\s)]+)\)|(?P<url>https://github\.com/user-attachments/[^\s)]+)")
+
+
+def parse_issue_form(body: str) -> dict[str, str]:
+    fields: dict[str, str] = {}
+    current: str | None = None
+    chunks: list[str] = []
+    for line in body.splitlines():
+        if line.startswith("### "):
+            if current is not None:
+                fields[current] = "\n".join(chunks).strip()
+            current = line.removeprefix("### ").strip()
+            chunks = []
+        elif current is not None:
+            chunks.append(line)
+    if current is not None:
+        fields[current] = "\n".join(chunks).strip()
+    return fields
+
+
+def first_line(value: str) -> str:
+    for line in value.splitlines():
+        text = line.strip()
+        if text and text != "_No response_":
+            return text
+    return ""
+
+
+def field_value(fields: dict[str, str], names: list[str]) -> str:
+    return next((fields[name] for name in names if name in fields), "")
+
+
+def parse_languages(value: str, extra: str) -> list[str]:
+    languages = [m.group(1).lower() for m in re.finditer(r"- \[[xX]\]\s*([a-z][a-z0-9_]*)\b", value)]
+    extra_text = first_line(extra).lower()
+    if extra_text and extra_text not in {"none", "n/a", "na", "no"}:
+        languages.extend(part.strip() for part in re.split(r"[,;\s]+", extra_text) if part.strip())
+    return sorted(set(languages))
+
+
+def extract_attachment(value: str) -> tuple[str, str, bool] | None:
+    matches = list(ATTACHMENT_RE.finditer(value))
+    if len(matches) != 1:
+        return None
+    match = matches[0]
+    url = match.group(2) or match.group("url")
+    filename_from_url = not bool(match.group(1))
+    filename = match.group(1) or Path(urllib.parse.urlparse(url).path).name
+    return urllib.parse.unquote(filename.strip()), url, filename_from_url
+
+
+def load_index() -> dict[str, Any]:
+    if not INDEX_PATH.exists():
+        return {"version": 1, "description": "Community-submitted Steam achievement schema translations.", "entries": []}
+    return json.loads(INDEX_PATH.read_text(encoding="utf-8"))
+
+
+def write_index(index: dict[str, Any]) -> None:
+    index["entries"] = sorted(index.get("entries", []), key=lambda e: (str(e.get("game_name", "")).casefold(), str(e.get("game_id", ""))))
+    INDEX_PATH.write_text(json.dumps(index, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+
+def escape_table(value: str) -> str:
+    return value.replace("|", "\\|").replace("\r", " ").replace("\n", " ").strip()
+
+
+def schema_download_url(schema_file: str) -> str:
+    path = urllib.parse.quote(schema_file.replace("\\", "/").lstrip("/"), safe="/")
+    repo = os.environ.get("GITHUB_REPOSITORY", "GaBoron/steam-achievement-translation-library")
+    return f"https://raw.githubusercontent.com/{repo}/main/{path}"
+
+
+def contributor_link(contributor: str) -> str:
+    return f"[@{escape_table(contributor)}](https://github.com/{urllib.parse.quote(contributor, safe='')})" if contributor else ""
+
+
+def write_human_indexes(index: dict[str, Any]) -> None:
+    entries = index.get("entries", [])
+    zh = ["# Steam 成就翻译库", "", "简体中文 | [English](README_EN.md)", "", "本仓库专门维护 Steam 成就翻译数据，不包含 Codex skill 本体。", "", "## 游戏列表", ""]
+    en = ["# Steam Achievement Translation Library", "", "[简体中文](README.md) | English", "", "This repository hosts Steam achievement translation data only; it does not include the Codex skill runtime.", "", "## Games", ""]
+    if entries:
+        header = ["| Steam app ID | 游戏 / Game | 贡献者 / Contributor | 支持语言 / Languages | 成就数 / Achievements | 成就文件 / Schema file | 商店 / Store |", "| --- | --- | --- | --- | ---: | --- | --- |"]
+        zh.extend(header)
+        en.extend(header)
+        for entry in entries:
+            schema_file = str(entry.get("schema_file", ""))
+            schema_name = PurePosixPath(schema_file).name
+            row = f"| `{entry.get('game_id', '')}` | {escape_table(str(entry.get('game_name', '')))} | {contributor_link(str(entry.get('contributor_id', '')))} | {escape_table(', '.join(entry.get('languages', [])))} | {entry.get('achievement_count', '')} | [`{schema_name}`]({schema_download_url(schema_file)}) | [Steam]({entry.get('store_url', '')}) |"
+            zh.append(row)
+            en.append(row)
+    else:
+        zh.append("暂无已收录游戏。")
+        en.append("No accepted games yet.")
+    HUMAN_INDEX_PATH.write_text("\n".join(zh) + "\n", encoding="utf-8")
+    HUMAN_INDEX_EN_PATH.write_text("\n".join(en) + "\n", encoding="utf-8")
+
+
+def fail(errors: list[str]) -> None:
+    Path("submission_result.json").write_text(json.dumps({"ok": False, "errors": errors}, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    raise SystemExit(1)
+
+
+def validate_and_update(event: dict[str, Any], token: str | None) -> dict[str, Any]:
+    issue = event["issue"]
+    fields = parse_issue_form(issue.get("body") or "")
+    game_name = first_line(field_value(fields, ["Game name", "游戏名"]))
+    game_id = first_line(field_value(fields, ["Steam app ID"]))
+    store_url = first_line(field_value(fields, ["Steam store URL", "Steam 商店地址"]))
+    languages = parse_languages(field_value(fields, ["Languages included in the uploaded file", "上传文件包含的语言"]), field_value(fields, ["Additional Steam language codes", "其他 Steam 语言代码"]))
+    attachment = extract_attachment(field_value(fields, ["Achievement schema ZIP", "Achievement schema file", "成就 schema ZIP", "成就 schema 文件"]))
+    errors: list[str] = []
+    if not game_name: errors.append("Game name is required.")
+    if not re.fullmatch(r"\d+", game_id): errors.append("Steam app ID must be numeric.")
+    if not re.search(r"store\.steampowered\.com/app/" + re.escape(game_id), store_url): errors.append("Steam store URL must match the submitted app ID.")
+    if not languages or any(not LANGUAGE_RE.fullmatch(language) for language in languages): errors.append("At least one valid Steam language code is required.")
+    if not attachment: errors.append("Attach exactly one UserGameStatsSchema_<app_id>.zip file.")
+    if errors: fail(errors)
+    filename, url, filename_from_url = attachment  # type: ignore[misc]
+    if not filename_from_url and not (ZIP_NAME_RE.fullmatch(filename) or SCHEMA_NAME_RE.fullmatch(filename)):
+        fail([f"Uploaded file must be UserGameStatsSchema_{game_id}.zip or .bin; got {filename}."])
+    with tempfile.TemporaryDirectory() as tmp:
+        downloaded = Path(tmp) / filename
+        request = urllib.request.Request(url, headers={"User-Agent": "steam-achievement-translation-library-bot"})
+        if token:
+            request.add_header("Authorization", f"Bearer {token}")
+        with urllib.request.urlopen(request, timeout=45) as response:
+            downloaded.write_bytes(response.read())
+        schema_path = downloaded
+        if zipfile.is_zipfile(downloaded):
+            with zipfile.ZipFile(downloaded) as archive:
+                files = [info for info in archive.infolist() if not info.is_dir()]
+                if len(files) != 1:
+                    fail(["ZIP upload must contain exactly one schema file."])
+                member = files[0]
+                if Path(member.filename).name != f"UserGameStatsSchema_{game_id}.bin":
+                    fail([f"ZIP upload must contain UserGameStatsSchema_{game_id}.bin."])
+                schema_path = Path(tmp) / f"UserGameStatsSchema_{game_id}.bin"
+                schema_path.write_bytes(archive.read(member))
+        target_dir = FILES_ROOT / game_id
+        target_dir.mkdir(parents=True, exist_ok=True)
+        target_file = target_dir / f"UserGameStatsSchema_{game_id}.bin"
+        shutil.copy2(schema_path, target_file)
+    index = load_index()
+    entry = {"game_name": game_name, "game_id": game_id, "store_url": store_url, "languages": languages, "schema_file": str(target_file.relative_to(REPO_ROOT)).replace("\\", "/"), "achievement_count": None, "source_issue": issue.get("html_url"), "contributor_id": (issue.get("user") or {}).get("login", "")}
+    index["entries"] = [e for e in index.get("entries", []) if str(e.get("game_id")) != game_id] + [entry]
+    write_index(index)
+    write_human_indexes(index)
+    result = {"ok": True, "branch": f"translation-library/issue-{issue['number']}", "pr_title": f"添加 {game_name} ({game_id}) 成就翻译", "game_id": game_id}
+    Path("submission_result.json").write_text(json.dumps(result, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    Path("pr_title.txt").write_text(result["pr_title"] + "\n", encoding="utf-8")
+    Path("pr_body.md").write_text(f"## 翻译投稿\n\n- 游戏：{game_name}\n- Steam app ID：`{game_id}`\n- 语言：{', '.join(languages)}\n- 来源 issue：{issue.get('html_url')}\n", encoding="utf-8")
+    return result
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--event", type=Path, required=True)
+    parser.add_argument("--token", default=os.environ.get("GITHUB_TOKEN"))
+    args = parser.parse_args()
+    validate_and_update(json.loads(args.event.read_text(encoding="utf-8")), args.token)
+
+
+if __name__ == "__main__":
+    main()

--- a/workflow-scripts/translation_pr_maintenance.py
+++ b/workflow-scripts/translation_pr_maintenance.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+"""Maintenance helper for translation-library pull requests."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+INDEX = ROOT / "index.json"
+
+
+def main() -> None:
+    data = json.loads(INDEX.read_text(encoding="utf-8"))
+    data["entries"] = sorted(data.get("entries", []), key=lambda e: (str(e.get("game_name", "")).casefold(), str(e.get("game_id", ""))))
+    INDEX.write_text(json.dumps(data, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Motivation

- 将原仓库中的社区翻译库部分独立为一个面向中文用户的独立仓库，保留翻译数据与投稿自动化而不带入 Codex skill 本体。 
- 中文文档、贡献指南与 issue 模板应为默认入口，以便中文社区直接投稿和使用。 
- 迁移过程中只读取原项目内容，不在原项目中删除、移动或修改任何原始 skill 文件。 

### Description

- 新增并以中文为默认入口的项目文档和贡献说明：`README.md`（中文默认）、`README_EN.md`（英文辅助）、`CONTRIBUTING.md`（中文默认）、`CONTRIBUTING_EN.md`（英文辅助）。
- 新增投稿表单与自动化：`.github/ISSUE_TEMPLATE/translation_contribution_zh.yml`、`.github/ISSUE_TEMPLATE/translation_contribution_en.yml`，以及工作流 `.github/workflows/translation-contribution.yml`。
- 迁移并调整维护脚本到根路径：新增 `workflow-scripts/library_submission_bot.py`、`workflow-scripts/github_issue_guard.py`、`workflow-scripts/translation_pr_maintenance.py`，所有脚本均使用根目录的 `files/`、`index.json`、`README.md`、`README_EN.md`；下载 URL 使用 `GITHUB_REPOSITORY` 环境变量并默认到 `GaBoron/steam-achievement-translation-library`。
- 新的仓库结构扁平化：新增根级 `files/`（含 `.gitkeep`）、`index.json`（空索引），并在文档与脚本中替换原来的 `achievement-library/` 前缀以避免嵌套（例如不再产生 `achievement-library/achievement-library`）。

迁移完成摘要：

- 迁移了的目录与文件：`achievement-library` 相关内容（以扁平化形式）被提炼到根级的 `files/`（社区 schema 文件）、`index.json`、`workflow-scripts/`（投稿维护脚本）、`.github/ISSUE_TEMPLATE/`（投稿模板）、`.github/workflows/translation-contribution.yml`、`README.md`、`README_EN.md`、`CONTRIBUTING.md`、`CONTRIBUTING_EN.md`。 
- 未迁移的 skill 本体内容：`SKILL.md`、`VERSION`、`scripts/steam_bkv_tool.py` 以及与 Codex skill 安装、打包、运行相关的说明与 workflow 均未被包含。 
- 修改了的路径与文档：将原 `achievement-library/files/` → `files/`，`achievement-library/index.json` → `index.json`，并在 `library_submission_bot.py` 等脚本中同步更新这些根路径与下载链接模板；README 与 CONTRIBUTING 明确中文为优先入口并说明不包含 skill 本体。 
- 原项目后续引用建议：原 skill 仓库应改为从该新仓库读取机器索引 `index.json` 与具体翻译文件 `files/<app_id>/UserGameStatsSchema_<app_id>.bin`，而不是继续访问原仓库内的 `achievement-library/` 子路径，skill 相关集成仅做读取/下载调用即可。 

### Testing

- 运行 `python3 -m py_compile workflow-scripts/*.py`，所有脚本字节码编译检查通过。 
- 运行 `python3 workflow-scripts/translation_pr_maintenance.py` 成功执行并对 `index.json` 应用排序写回。 
- 使用 `rg -n "achievement-library|steam-achievement-localizer-skill|SKILL.md|VERSION|steam_bkv_tool|scripts/" . --glob '!.git/**'` 检查仓库内硬编码引用，未发现残留的旧 `achievement-library/` 依赖（检查通过）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a494f4d6bd08326907cfea7e0ebfd5b)